### PR TITLE
Add missing arg for creating new project example

### DIFF
--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -58,7 +58,7 @@
     </header>
     <p>Let’s write a small application with our new Rust development environment. To start, we’ll use Cargo to
       make a new project for us. In your terminal of choice run:</p>
-    <p><code>cargo new hello-rust</code></p>
+    <p><code>cargo new --bin hello-rust</code></p>
     <p>This will generate a new directory called <code>hello-rust</code> with the following files:</p>
     <pre><code>hello-rust
 |- Cargo.toml


### PR DESCRIPTION
It seems `cargo new` currently defaults to using a library template to create a new project, but the "Generating new project" example assumes it will use the binary template. 

The library template is incompatible with the next steps in the example. When you try to run `cargo run`, you get an error:

```
➜  hello-rust git:(master) ✗ cargo run
error: a bin target must be available for `cargo run`
```

This PR adds the missing `--bin` argument to make the example correct.